### PR TITLE
feat: Add pluggable embedding providers (Jina, Voyage, OpenAI, Ollama)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,25 @@
-# Embeddings (Jina Code V2 via HuggingFace TEI)
-EMBEDDINGS_URL=http://localhost:8087
+# Embeddings provider — one of: jina | voyage | openai | ollama
+EMBEDDINGS_PROVIDER=jina
+
+# Jina Code V2 via HuggingFace TEI (default)
+JINA_URL=http://localhost:8087
+JINA_MODEL=jinaai/jina-embeddings-v2-base-code
+JINA_DIMENSIONS=768
+
+# Voyage AI — set EMBEDDINGS_PROVIDER=voyage to use
+# VOYAGE_API_KEY=
+# VOYAGE_MODEL=voyage-code-3
+# VOYAGE_DIMENSIONS=        # optional override (e.g. 256, 512, 1024, 2048)
+
+# OpenAI — set EMBEDDINGS_PROVIDER=openai to use
+# OPENAI_API_KEY=
+# OPENAI_EMBEDDING_MODEL=text-embedding-3-large
+# OPENAI_DIMENSIONS=        # optional override
+
+# Ollama — set EMBEDDINGS_PROVIDER=ollama to use
+# OLLAMA_URL=http://localhost:11434
+# OLLAMA_MODEL=nomic-embed-text
+# OLLAMA_DIMENSIONS=        # required for models not in the built-in table
 
 # Qdrant
 QDRANT_URL=http://localhost:6333

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ language queries or symbol name lookups.
 
 1. Fetches source files from configured GitHub repositories
 2. Parses code symbols (functions, classes, methods, components) using Tree-sitter
-3. Generates embeddings via Jina Code V2 (served by HuggingFace TEI)
+3. Generates embeddings via a pluggable provider — Jina Code V2 (TEI) by default, or Voyage / OpenAI / Ollama
 4. Stores vectors in Qdrant for fast semantic search
 5. Optionally indexes commit history into a separate Qdrant collection
 6. Exposes search and indexing tools through the MCP protocol (and a small HTTP API)
@@ -97,7 +97,7 @@ chunk with a vector embedding and a rich payload.
 - **Change detection** — compares the file's Git blob SHA to the last indexed value; unchanged files are skipped
 - **Parsing** — Tree-sitter walks the AST and emits `CodeSymbol` objects per language
 - **Embedding text** — built from signature, docstring, annotations, parent name, and source (truncated at ~6000 chars)
-- **Batching** — symbols are embedded in batches of 32 against the TEI server
+- **Batching** — batched per-provider (32 for Jina/TEI and Ollama, 128 for Voyage and OpenAI)
 - **Upsert** — vectors stored in Qdrant under deterministic UUIDs (per service / file / symbol / line)
 - **Cleanup** — entries for files no longer in the repo are deleted
 
@@ -158,19 +158,51 @@ any context where observing indexing progress matters.
 
 ## Environment variables
 
-| Variable                    | Default                               | Description                                |
-|-----------------------------|---------------------------------------|--------------------------------------------|
-| `GITHUB_TOKEN`              | *(required)*                          | GitHub token with repo read access         |
-| `QDRANT_URL`                | `http://localhost:6333`               | Qdrant connection URL                      |
-| `QDRANT_COLLECTION`         | `code_symbols`                        | Collection name for code symbol vectors    |
-| `QDRANT_COMMITS_COLLECTION` | `git_commits`                         | Collection name for commit message vectors |
-| `EMBEDDINGS_URL`            | `http://localhost:8087`               | Jina TEI URL                               |
-| `EMBEDDINGS_MODEL`          | `jinaai/jina-embeddings-v2-base-code` | Embedding model ID                         |
-| `EMBEDDINGS_DIMENSIONS`     | `768`                                 | Vector dimensions                          |
-| `GIT_HISTORY_MAX_COMMITS`   | `500`                                 | Max commits indexed per service            |
-| `MCP_TRANSPORT`             | `streamable-http`                     | One of `streamable-http`, `sse`, `stdio`   |
-| `MCP_HOST` / `MCP_PORT`     | `0.0.0.0` / `8090`                    | Server bind address                        |
-| `CONFIG_PATH`               | `./config.yaml`                       | Path to the services config file           |
+| Variable                    | Default                 | Description                                |
+|-----------------------------|-------------------------|--------------------------------------------|
+| `GITHUB_TOKEN`              | *(required)*            | GitHub token with repo read access         |
+| `QDRANT_URL`                | `http://localhost:6333` | Qdrant connection URL                      |
+| `QDRANT_COLLECTION`         | `code_symbols`          | Collection name for code symbol vectors    |
+| `QDRANT_COMMITS_COLLECTION` | `git_commits`           | Collection name for commit message vectors |
+| `EMBEDDINGS_PROVIDER`       | `jina`                  | One of `jina`, `voyage`, `openai`, `ollama` — see *Embedding providers* below |
+| `GIT_HISTORY_MAX_COMMITS`   | `500`                   | Max commits indexed per service            |
+| `MCP_TRANSPORT`             | `streamable-http`       | One of `streamable-http`, `sse`, `stdio`   |
+| `MCP_HOST` / `MCP_PORT`     | `0.0.0.0` / `8090`      | Server bind address                        |
+| `CONFIG_PATH`               | `./config.yaml`         | Path to the services config file           |
+
+## Embedding providers
+
+The embedding backend is selectable via `EMBEDDINGS_PROVIDER`. Default is `jina` so existing
+deployments keep working unchanged. Each provider derives its own vector dimensions from the
+configured model — no need to set dimensions manually unless you want to override.
+
+| Variable                 | Default                               | Applies to | Description                                                                       |
+|--------------------------|---------------------------------------|------------|-----------------------------------------------------------------------------------|
+| `JINA_URL`               | `http://localhost:8087`               | `jina`     | TEI base URL                                                                      |
+| `JINA_MODEL`             | `jinaai/jina-embeddings-v2-base-code` | `jina`     | Model ID served by TEI (informational — the running TEI container chooses)        |
+| `JINA_DIMENSIONS`        | `768`                                 | `jina`     | Vector dimensions of the TEI model                                                |
+| `VOYAGE_API_KEY`         | *(required if provider=voyage)*       | `voyage`   | Voyage AI API key                                                                 |
+| `VOYAGE_MODEL`           | `voyage-code-3`                       | `voyage`   | Voyage embedding model                                                            |
+| `VOYAGE_DIMENSIONS`      | *(native)*                            | `voyage`   | Optional override — Voyage code-3 supports `256` / `512` / `1024` / `2048`        |
+| `OPENAI_API_KEY`         | *(required if provider=openai)*       | `openai`   | OpenAI API key                                                                    |
+| `OPENAI_EMBEDDING_MODEL` | `text-embedding-3-large`              | `openai`   | OpenAI embedding model                                                            |
+| `OPENAI_DIMENSIONS`      | *(native)*                            | `openai`   | Optional override (text-embedding-3-* models support shrinking)                   |
+| `OLLAMA_URL`             | `http://localhost:11434`              | `ollama`   | Ollama base URL                                                                   |
+| `OLLAMA_MODEL`           | `nomic-embed-text`                    | `ollama`   | Ollama embedding model                                                            |
+| `OLLAMA_DIMENSIONS`      | *(native)*                            | `ollama`   | Required if using a model not in the built-in dimensions table                    |
+
+`voyage-code-3` outperforms `jinaai/jina-embeddings-v2-base-code` on most code retrieval benchmarks,
+so switching to Voyage is also a quality lever, not just a flexibility one.
+
+**Switching providers against an existing index:** if the new provider's vector size differs from
+the existing Qdrant collection, the server fails fast at startup with a clear error pointing at the
+offending collection. To switch, drop both collections (`code_symbols` and `git_commits`) via the
+Qdrant UI or API, then reindex. There is no automatic migration.
+
+**Hosted-only setup (no local TEI container):** in `docker-compose.yaml`, comment out the entire
+`jina-embeddings` service block, the `jina-embeddings` entry under `semcode.depends_on`, and the
+`JINA_URL` line under `semcode.environment`. Then set `EMBEDDINGS_PROVIDER` and the relevant API
+key in `.env`.
 
 ## Qdrant collections
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,13 @@ services:
       timeout: 5s
       retries: 5
 
+  # Jina Code V2 served by HuggingFace Text Embeddings Inference. Default
+  # embedding backend. To use a hosted provider instead (Voyage / OpenAI) or a
+  # local Ollama install, set EMBEDDINGS_PROVIDER + the relevant API key in
+  # .env, then comment out:
+  #   1. this entire `jina-embeddings` service
+  #   2. the `jina-embeddings` entry under `semcode.depends_on`
+  #   3. the JINA_URL line under `semcode.environment`
   jina-embeddings:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.6
     platform: linux/amd64
@@ -35,7 +42,7 @@ services:
     env_file:
       - .env
     environment:
-      EMBEDDINGS_URL: http://jina-embeddings:80
+      JINA_URL: http://jina-embeddings:80
       QDRANT_URL: http://qdrant:6333
       MCP_HOST: 0.0.0.0
       FASTEMBED_CACHE_PATH: /fastembed_cache

--- a/server/config.py
+++ b/server/config.py
@@ -23,14 +23,39 @@ class ServiceConfig:
         self.exclude = exclude
 
 
+EmbeddingsProviderName = Literal["jina", "voyage", "openai", "ollama"]
+
+
 class Settings(BaseSettings):
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8", "extra": "ignore"}
 
-    embeddings_url: str = Field(default="http://localhost:8087", alias="EMBEDDINGS_URL")
-    embeddings_model: str = Field(
-        default="jinaai/jina-embeddings-v2-base-code", alias="EMBEDDINGS_MODEL"
+    embeddings_provider: EmbeddingsProviderName = Field(
+        default="jina", alias="EMBEDDINGS_PROVIDER"
     )
-    embeddings_dimensions: int = Field(default=768, alias="EMBEDDINGS_DIMENSIONS")
+
+    # Jina (TEI / self-hosted HuggingFace text-embeddings-inference)
+    jina_url: str = Field(default="http://localhost:8087", alias="JINA_URL")
+    jina_model: str = Field(
+        default="jinaai/jina-embeddings-v2-base-code", alias="JINA_MODEL"
+    )
+    jina_dimensions: int = Field(default=768, alias="JINA_DIMENSIONS")
+
+    # Voyage AI
+    voyage_api_key: str = Field(default="", alias="VOYAGE_API_KEY")
+    voyage_model: str = Field(default="voyage-code-3", alias="VOYAGE_MODEL")
+    voyage_dimensions: int | None = Field(default=None, alias="VOYAGE_DIMENSIONS")
+
+    # OpenAI
+    openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
+    openai_embedding_model: str = Field(
+        default="text-embedding-3-large", alias="OPENAI_EMBEDDING_MODEL"
+    )
+    openai_dimensions: int | None = Field(default=None, alias="OPENAI_DIMENSIONS")
+
+    # Ollama
+    ollama_url: str = Field(default="http://localhost:11434", alias="OLLAMA_URL")
+    ollama_model: str = Field(default="nomic-embed-text", alias="OLLAMA_MODEL")
+    ollama_dimensions: int | None = Field(default=None, alias="OLLAMA_DIMENSIONS")
 
     qdrant_url: str = Field(default="http://localhost:6333", alias="QDRANT_URL")
     qdrant_collection: str = Field(default="code_symbols", alias="QDRANT_COLLECTION")

--- a/server/embeddings/factory.py
+++ b/server/embeddings/factory.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from server.config import settings
+from server.embeddings.base import EmbeddingProvider
+
+_provider: EmbeddingProvider | None = None
+
+
+def get_embedding_provider() -> EmbeddingProvider:
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    name = settings.embeddings_provider
+    if name == "jina":
+        from server.embeddings.jina import JinaEmbeddingProvider
+
+        _provider = JinaEmbeddingProvider()
+    elif name == "voyage":
+        from server.embeddings.voyage import VoyageEmbeddingProvider
+
+        _provider = VoyageEmbeddingProvider()
+    elif name == "openai":
+        from server.embeddings.openai import OpenAIEmbeddingProvider
+
+        _provider = OpenAIEmbeddingProvider()
+    elif name == "ollama":
+        from server.embeddings.ollama import OllamaEmbeddingProvider
+
+        _provider = OllamaEmbeddingProvider()
+    else:
+        raise ValueError(
+            f"Unknown EMBEDDINGS_PROVIDER {name!r}. "
+            "Expected one of: jina, voyage, openai, ollama."
+        )
+    return _provider
+
+
+async def close_embedding_provider() -> None:
+    global _provider
+    if _provider is None:
+        return
+    close = getattr(_provider, "close", None)
+    if close is not None:
+        await close()
+    _provider = None

--- a/server/embeddings/ollama.py
+++ b/server/embeddings/ollama.py
@@ -9,17 +9,35 @@ from server.embeddings.base import EmbeddingProvider
 
 logger = logging.getLogger(__name__)
 
-# HuggingFace TEI uses the OpenAI-compatible /embed endpoint
-_EMBED_PATH = "/embed"
+_EMBED_PATH = "/api/embed"
 _BATCH_SIZE = 32
 
+_NATIVE_DIMENSIONS: dict[str, int] = {
+    "nomic-embed-text": 768,
+    "mxbai-embed-large": 1024,
+    "all-minilm": 384,
+    "snowflake-arctic-embed": 1024,
+    "bge-m3": 1024,
+}
 
-class JinaEmbeddingProvider(EmbeddingProvider):
-    """Calls the self-hosted Jina Code V2 model via HuggingFace Text Embeddings Inference."""
+
+class OllamaEmbeddingProvider(EmbeddingProvider):
+    """Ollama embeddings — see https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings."""
 
     def __init__(self) -> None:
-        self._base_url = settings.jina_url.rstrip("/")
-        self._dims = settings.jina_dimensions
+        self._base_url = settings.ollama_url.rstrip("/")
+        self._model = settings.ollama_model
+        self._dims_override = settings.ollama_dimensions
+        if self._dims_override is not None:
+            self._dims = self._dims_override
+        elif self._model in _NATIVE_DIMENSIONS:
+            self._dims = _NATIVE_DIMENSIONS[self._model]
+        else:
+            raise RuntimeError(
+                f"Unknown Ollama model {self._model!r} — set OLLAMA_DIMENSIONS "
+                "to declare the output size, or use a known model "
+                f"({', '.join(sorted(_NATIVE_DIMENSIONS))})."
+            )
         self._client = httpx.AsyncClient(timeout=120.0)
 
     @property
@@ -34,19 +52,14 @@ class JinaEmbeddingProvider(EmbeddingProvider):
             batch = texts[i : i + _BATCH_SIZE]
             resp = await self._client.post(
                 f"{self._base_url}{_EMBED_PATH}",
-                json={"inputs": batch},
+                json={"model": self._model, "input": batch},
             )
             resp.raise_for_status()
             data = resp.json()
-            # TEI returns a list of vectors directly
-            if isinstance(data, list):
-                batch_vectors: list[list[float]] = data
-            else:
-                # fallback: OpenAI-style { "data": [...] }
-                batch_vectors = [item["embedding"] for item in data.get("data", [])]
+            batch_vectors = data.get("embeddings", [])
             if len(batch_vectors) != len(batch):
                 raise ValueError(
-                    f"Embedding server returned {len(batch_vectors)} vectors for "
+                    f"Ollama returned {len(batch_vectors)} vectors for "
                     f"{len(batch)} inputs — response may be malformed"
                 )
             all_vectors.extend(batch_vectors)

--- a/server/embeddings/openai.py
+++ b/server/embeddings/openai.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from server.config import settings
+from server.embeddings.base import EmbeddingProvider
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.openai.com/v1/embeddings"
+# OpenAI accepts up to 2048 inputs per request; 128 is conservative and matches
+# Voyage's cap so behaviour is uniform across providers.
+_BATCH_SIZE = 128
+
+_NATIVE_DIMENSIONS: dict[str, int] = {
+    "text-embedding-3-large": 3072,
+    "text-embedding-3-small": 1536,
+    "text-embedding-ada-002": 1536,
+}
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    """OpenAI embeddings — see https://platform.openai.com/docs/api-reference/embeddings."""
+
+    def __init__(self) -> None:
+        if not settings.openai_api_key:
+            raise RuntimeError(
+                "OPENAI_API_KEY is not set but EMBEDDINGS_PROVIDER=openai."
+            )
+        self._api_key = settings.openai_api_key
+        self._model = settings.openai_embedding_model
+        self._dims_override = settings.openai_dimensions
+        if self._dims_override is not None:
+            self._dims = self._dims_override
+        elif self._model in _NATIVE_DIMENSIONS:
+            self._dims = _NATIVE_DIMENSIONS[self._model]
+        else:
+            raise RuntimeError(
+                f"Unknown OpenAI embedding model {self._model!r} — set "
+                "OPENAI_DIMENSIONS to declare the output size, or use a known model "
+                f"({', '.join(sorted(_NATIVE_DIMENSIONS))})."
+            )
+        self._client = httpx.AsyncClient(
+            timeout=120.0,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    @property
+    def dimensions(self) -> int:
+        return self._dims
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        all_vectors: list[list[float]] = []
+        for i in range(0, len(texts), _BATCH_SIZE):
+            batch = texts[i : i + _BATCH_SIZE]
+            body: dict = {"model": self._model, "input": batch}
+            if self._dims_override is not None:
+                body["dimensions"] = self._dims_override
+            resp = await self._client.post(_API_URL, json=body)
+            resp.raise_for_status()
+            data = resp.json()
+            batch_vectors = [item["embedding"] for item in data.get("data", [])]
+            if len(batch_vectors) != len(batch):
+                raise ValueError(
+                    f"OpenAI returned {len(batch_vectors)} vectors for "
+                    f"{len(batch)} inputs — response may be malformed"
+                )
+            all_vectors.extend(batch_vectors)
+        return all_vectors
+
+    async def embed_query(self, text: str) -> list[float]:
+        vectors = await self.embed_batch([text])
+        return vectors[0] if vectors else []
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/server/embeddings/openai.py
+++ b/server/embeddings/openai.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 _API_URL = "https://api.openai.com/v1/embeddings"
 # OpenAI accepts up to 2048 inputs per request; 128 is conservative and matches
-# Voyage's cap so behaviour is uniform across providers.
+# Voyage's cap, so behavior is uniform across providers.
 _BATCH_SIZE = 128
 _BACKOFF_DELAYS = [10, 20, 30, 40]
 

--- a/server/embeddings/openai.py
+++ b/server/embeddings/openai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import httpx
@@ -13,6 +14,7 @@ _API_URL = "https://api.openai.com/v1/embeddings"
 # OpenAI accepts up to 2048 inputs per request; 128 is conservative and matches
 # Voyage's cap so behaviour is uniform across providers.
 _BATCH_SIZE = 128
+_BACKOFF_DELAYS = [10, 20, 30, 40]
 
 _NATIVE_DIMENSIONS: dict[str, int] = {
     "text-embedding-3-large": 3072,
@@ -63,7 +65,18 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             body: dict = {"model": self._model, "input": batch}
             if self._dims_override is not None:
                 body["dimensions"] = self._dims_override
-            resp = await self._client.post(_API_URL, json=body)
+            for attempt in range(4):
+                resp = await self._client.post(_API_URL, json=body)
+                if resp.status_code != 429:
+                    break
+                retry_after = float(resp.headers.get("Retry-After", 0))
+                wait = retry_after if retry_after > 0 else _BACKOFF_DELAYS[attempt]
+                logger.warning(
+                    "OpenAI rate-limited (429) — retrying in %.0fs (attempt %d/4)",
+                    wait,
+                    attempt + 1,
+                )
+                await asyncio.sleep(wait)
             resp.raise_for_status()
             data = resp.json()
             batch_vectors = [item["embedding"] for item in data.get("data", [])]

--- a/server/embeddings/voyage.py
+++ b/server/embeddings/voyage.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from server.config import settings
+from server.embeddings.base import EmbeddingProvider
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.voyageai.com/v1/embeddings"
+# Voyage caps batch size at 128 inputs per request.
+_BATCH_SIZE = 128
+
+# Native output dimensions for known models. Some models (voyage-code-3, voyage-3,
+# voyage-3-large) accept an `output_dimension` API parameter to shrink/grow this;
+# users override via VOYAGE_DIMENSIONS.
+_NATIVE_DIMENSIONS: dict[str, int] = {
+    "voyage-code-3": 1024,
+    "voyage-3": 1024,
+    "voyage-3-large": 1024,
+    "voyage-3-lite": 512,
+    "voyage-large-2": 1536,
+    "voyage-2": 1024,
+    "voyage-code-2": 1536,
+}
+
+
+class VoyageEmbeddingProvider(EmbeddingProvider):
+    """Voyage AI embeddings — see https://docs.voyageai.com/reference/embeddings-api."""
+
+    def __init__(self) -> None:
+        if not settings.voyage_api_key:
+            raise RuntimeError(
+                "VOYAGE_API_KEY is not set but EMBEDDINGS_PROVIDER=voyage."
+            )
+        self._api_key = settings.voyage_api_key
+        self._model = settings.voyage_model
+        self._dims_override = settings.voyage_dimensions
+        if self._dims_override is not None:
+            self._dims = self._dims_override
+        elif self._model in _NATIVE_DIMENSIONS:
+            self._dims = _NATIVE_DIMENSIONS[self._model]
+        else:
+            raise RuntimeError(
+                f"Unknown Voyage model {self._model!r} — set VOYAGE_DIMENSIONS "
+                "to declare the output size, or use a known model "
+                f"({', '.join(sorted(_NATIVE_DIMENSIONS))})."
+            )
+        self._client = httpx.AsyncClient(
+            timeout=120.0,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    @property
+    def dimensions(self) -> int:
+        return self._dims
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return await self._embed(texts, input_type="document")
+
+    async def embed_query(self, text: str) -> list[float]:
+        vectors = await self._embed([text], input_type="query")
+        return vectors[0] if vectors else []
+
+    async def _embed(
+        self, texts: list[str], input_type: str
+    ) -> list[list[float]]:
+        if not texts:
+            return []
+        all_vectors: list[list[float]] = []
+        for i in range(0, len(texts), _BATCH_SIZE):
+            batch = texts[i : i + _BATCH_SIZE]
+            body: dict = {
+                "model": self._model,
+                "input": batch,
+                "input_type": input_type,
+            }
+            if self._dims_override is not None:
+                body["output_dimension"] = self._dims_override
+            resp = await self._client.post(_API_URL, json=body)
+            resp.raise_for_status()
+            data = resp.json()
+            batch_vectors = [item["embedding"] for item in data.get("data", [])]
+            if len(batch_vectors) != len(batch):
+                raise ValueError(
+                    f"Voyage returned {len(batch_vectors)} vectors for "
+                    f"{len(batch)} inputs — response may be malformed"
+                )
+            all_vectors.extend(batch_vectors)
+        return all_vectors
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/server/embeddings/voyage.py
+++ b/server/embeddings/voyage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import httpx
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 _API_URL = "https://api.voyageai.com/v1/embeddings"
 # Voyage caps batch size at 128 inputs per request.
 _BATCH_SIZE = 128
+_BACKOFF_DELAYS = [10, 20, 30, 40]
 
 # Native output dimensions for known models. Some models (voyage-code-3, voyage-3,
 # voyage-3-large) accept an `output_dimension` API parameter to shrink/grow this;
@@ -67,9 +69,7 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
         vectors = await self._embed([text], input_type="query")
         return vectors[0] if vectors else []
 
-    async def _embed(
-        self, texts: list[str], input_type: str
-    ) -> list[list[float]]:
+    async def _embed(self, texts: list[str], input_type: str) -> list[list[float]]:
         if not texts:
             return []
         all_vectors: list[list[float]] = []
@@ -82,7 +82,18 @@ class VoyageEmbeddingProvider(EmbeddingProvider):
             }
             if self._dims_override is not None:
                 body["output_dimension"] = self._dims_override
-            resp = await self._client.post(_API_URL, json=body)
+            for attempt in range(4):
+                resp = await self._client.post(_API_URL, json=body)
+                if resp.status_code != 429:
+                    break
+                retry_after = float(resp.headers.get("Retry-After", 0))
+                wait = retry_after if retry_after > 0 else _BACKOFF_DELAYS[attempt]
+                logger.warning(
+                    "Voyage rate-limited (429) — retrying in %.0fs (attempt %d/4)",
+                    wait,
+                    attempt + 1,
+                )
+                await asyncio.sleep(wait)
             resp.raise_for_status()
             data = resp.json()
             batch_vectors = [item["embedding"] for item in data.get("data", [])]

--- a/server/indexer/git_history.py
+++ b/server/indexer/git_history.py
@@ -9,7 +9,7 @@ import httpx
 
 from server.config import settings
 from server.embeddings.base import EmbeddingProvider
-from server.embeddings.jina import get_embedding_provider
+from server.embeddings.factory import get_embedding_provider
 from server.indexer.github_source import (
     GitHubCommit,
     fetch_commits_with_diffs,

--- a/server/indexer/pipeline.py
+++ b/server/indexer/pipeline.py
@@ -13,7 +13,7 @@ import httpx
 from server.config import settings
 from server.embeddings.base import EmbeddingProvider
 from server.embeddings.bm25 import BM25SparseProvider, get_sparse_embedding_provider
-from server.embeddings.jina import get_embedding_provider
+from server.embeddings.factory import get_embedding_provider
 from server.indexer.github_source import fetch_blob_content, list_github_files
 from server.parser.base import CodeSymbol
 from server.parser.registry import parse_file

--- a/server/main.py
+++ b/server/main.py
@@ -10,7 +10,7 @@ from starlette.applications import Starlette
 
 from server.config import settings
 from server.embeddings.bm25 import BM25SparseProvider, close_sparse_embedding_provider
-from server.embeddings.jina import close_embedding_provider
+from server.embeddings.factory import close_embedding_provider, get_embedding_provider
 from server.state import (
     get_commit_store,
     get_store,
@@ -28,11 +28,18 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(_: FastMCP) -> AsyncIterator[None]:
     logger.info("Starting semcode MCP server...")
-    store = QdrantStore()
+    embedder = get_embedding_provider()
+    logger.info(
+        "Embedding provider: %s (dimensions=%d)",
+        settings.embeddings_provider,
+        embedder.dimensions,
+    )
+
+    store = QdrantStore(dimensions=embedder.dimensions)
     await store.ensure_collection()
     set_store(store)
 
-    commit_store = CommitStore()
+    commit_store = CommitStore(dimensions=embedder.dimensions)
     await commit_store.ensure_collection()
     set_commit_store(commit_store)
 

--- a/server/store/commit_store.py
+++ b/server/store/commit_store.py
@@ -26,23 +26,40 @@ def _commit_point_id(service: str, sha: str) -> str:
 
 
 class CommitStore:
-    def __init__(self) -> None:
+    def __init__(self, dimensions: int) -> None:
         self._client = AsyncQdrantClient(url=settings.qdrant_url)
         self._collection = settings.qdrant_commits_collection
+        self._dimensions = dimensions
 
     async def ensure_collection(self) -> None:
         exists = await self._client.collection_exists(self._collection)
-        if not exists:
+        if exists:
+            await self._validate_dimensions()
+        else:
             await self._client.create_collection(
                 collection_name=self._collection,
                 vectors_config=VectorParams(
-                    size=settings.embeddings_dimensions,
+                    size=self._dimensions,
                     distance=Distance.COSINE,
                 ),
                 optimizers_config=OptimizersConfigDiff(indexing_threshold=500),
                 hnsw_config=HnswConfigDiff(m=16, ef_construct=128),
             )
         await self._create_payload_indexes()
+
+    async def _validate_dimensions(self) -> None:
+        info = await self._client.get_collection(self._collection)
+        vectors = info.config.params.vectors
+        params = vectors["text-dense"] if isinstance(vectors, dict) else vectors
+        actual = params.size
+        if actual != self._dimensions:
+            raise RuntimeError(
+                f"Qdrant collection {self._collection!r} was created with vector size "
+                f"{actual}, but the configured embedding provider produces vectors of "
+                f"size {self._dimensions}. Either revert EMBEDDINGS_PROVIDER to the "
+                "original setting, or drop the collection (this deletes the existing "
+                "index) and reindex."
+            )
 
     async def _create_payload_indexes(self) -> None:
         for field_name in ["service", "author_name", "sha"]:

--- a/server/store/qdrant.py
+++ b/server/store/qdrant.py
@@ -34,30 +34,48 @@ def _symbol_point_id(
 
 
 class QdrantStore:
-    def __init__(self) -> None:
+    def __init__(self, dimensions: int) -> None:
         self._client = AsyncQdrantClient(url=settings.qdrant_url)
         self._collection = settings.qdrant_collection
+        self._dimensions = dimensions
 
     async def ensure_collection(self) -> None:
         exists = await self._client.collection_exists(self._collection)
-        if not exists:
-            await self._client.create_collection(
-                collection_name=self._collection,
-                vectors_config={
-                    "text-dense": VectorParams(
-                        size=settings.embeddings_dimensions,
-                        distance=Distance.COSINE,
-                    ),
-                },
-                sparse_vectors_config={
-                    "text-sparse": SparseVectorParams(
-                        index=SparseIndexParams(on_disk=False),
-                    ),
-                },
-                optimizers_config=OptimizersConfigDiff(indexing_threshold=500),
-                hnsw_config=HnswConfigDiff(m=16, ef_construct=128),
+        if exists:
+            await self._validate_dimensions()
+            return
+        await self._client.create_collection(
+            collection_name=self._collection,
+            vectors_config={
+                "text-dense": VectorParams(
+                    size=self._dimensions,
+                    distance=Distance.COSINE,
+                ),
+            },
+            sparse_vectors_config={
+                "text-sparse": SparseVectorParams(
+                    index=SparseIndexParams(on_disk=False),
+                ),
+            },
+            optimizers_config=OptimizersConfigDiff(indexing_threshold=500),
+            hnsw_config=HnswConfigDiff(m=16, ef_construct=128),
+        )
+        await self._create_payload_indexes()
+
+    async def _validate_dimensions(self) -> None:
+        info = await self._client.get_collection(self._collection)
+        vectors = info.config.params.vectors
+        # Named-vector collections expose a dict; single-vector collections expose VectorParams.
+        params = vectors["text-dense"] if isinstance(vectors, dict) else vectors
+        actual = params.size
+        if actual != self._dimensions:
+            raise RuntimeError(
+                f"Qdrant collection {self._collection!r} was created with vector size "
+                f"{actual}, but the configured embedding provider produces vectors of "
+                f"size {self._dimensions}. Either revert EMBEDDINGS_PROVIDER to the "
+                "original setting, or drop the collection (this deletes the existing "
+                "index) and reindex."
             )
-            await self._create_payload_indexes()
 
     async def _create_payload_indexes(self) -> None:
         keyword_fields = [
@@ -306,7 +324,7 @@ class QdrantStore:
             "collection": self._collection,
             "total_vectors": info.points_count,
             "status": str(info.status),
-            "vector_size": settings.embeddings_dimensions,
+            "vector_size": self._dimensions,
         }
 
     async def close(self) -> None:

--- a/server/tools/admin.py
+++ b/server/tools/admin.py
@@ -59,6 +59,14 @@ def register_admin_tools(mcp: FastMCP) -> None:
             lines.append(f"- `{svc.name}` — `{svc.github_repo}@{svc.github_ref}`")
 
         lines.append("")
-        lines.append(f"**Embeddings URL**: {settings.embeddings_url}")
+        lines.append(f"**Embeddings provider**: {settings.embeddings_provider}")
+        provider_endpoint = {
+            "jina": settings.jina_url,
+            "ollama": settings.ollama_url,
+            "voyage": "https://api.voyageai.com/v1/embeddings",
+            "openai": "https://api.openai.com/v1/embeddings",
+        }.get(settings.embeddings_provider)
+        if provider_endpoint:
+            lines.append(f"**Embeddings endpoint**: {provider_endpoint}")
 
         return "\n".join(lines)

--- a/server/tools/history.py
+++ b/server/tools/history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from server.embeddings.jina import get_embedding_provider
+from server.embeddings.factory import get_embedding_provider
 from server.indexer.git_history import GitHistoryPipeline
 from server.state import get_commit_store
 

--- a/server/tools/search.py
+++ b/server/tools/search.py
@@ -6,7 +6,7 @@ import httpx
 from mcp.server.fastmcp import FastMCP
 
 from server.config import settings
-from server.embeddings.jina import get_embedding_provider
+from server.embeddings.factory import get_embedding_provider
 from server.indexer.github_source import fetch_file_content
 from server.state import get_sparse_provider, get_store
 

--- a/tests/embeddings/test_jina.py
+++ b/tests/embeddings/test_jina.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from server.config import settings
+from server.embeddings.jina import JinaEmbeddingProvider
+
+
+@pytest.fixture
+def jina_settings(monkeypatch):
+    monkeypatch.setattr(settings, "jina_url", "http://tei-test:80")
+    monkeypatch.setattr(settings, "jina_dimensions", 768)
+
+
+@pytest.fixture
+async def provider(jina_settings):
+    p = JinaEmbeddingProvider()
+    yield p
+    await p.close()
+
+
+@respx.mock
+async def test_embed_batch_posts_to_embed_endpoint(provider):
+    route = respx.post("http://tei-test:80/embed").mock(
+        return_value=httpx.Response(200, json=[[0.1] * 768, [0.2] * 768])
+    )
+    vectors = await provider.embed_batch(["hello", "world"])
+
+    assert route.called
+    body = route.calls.last.request.read()
+    import json
+
+    assert json.loads(body) == {"inputs": ["hello", "world"]}
+    assert len(vectors) == 2
+    assert len(vectors[0]) == 768
+
+
+@respx.mock
+async def test_embed_batch_chunks_at_32(provider):
+    route = respx.post("http://tei-test:80/embed").mock(
+        side_effect=lambda req: httpx.Response(
+            200,
+            json=[[0.0] * 768] * len(__import__("json").loads(req.read())["inputs"]),
+        )
+    )
+    vectors = await provider.embed_batch([f"text-{i}" for i in range(70)])
+
+    # 70 inputs / batch size 32 = 3 calls (32, 32, 6)
+    assert route.call_count == 3
+    assert len(vectors) == 70
+
+
+@respx.mock
+async def test_embed_batch_supports_openai_style_response(provider):
+    respx.post("http://tei-test:80/embed").mock(
+        return_value=httpx.Response(
+            200, json={"data": [{"embedding": [0.5] * 768}]}
+        )
+    )
+    vectors = await provider.embed_batch(["hello"])
+    assert vectors == [[0.5] * 768]
+
+
+@respx.mock
+async def test_embed_query_returns_single_vector(provider):
+    respx.post("http://tei-test:80/embed").mock(
+        return_value=httpx.Response(200, json=[[0.3] * 768])
+    )
+    vec = await provider.embed_query("query")
+    assert len(vec) == 768
+    assert vec[0] == 0.3
+
+
+async def test_embed_batch_empty_returns_empty(provider):
+    assert await provider.embed_batch([]) == []
+
+
+def test_dimensions_reads_from_settings(jina_settings, monkeypatch):
+    monkeypatch.setattr(settings, "jina_dimensions", 1024)
+    p = JinaEmbeddingProvider()
+    assert p.dimensions == 1024

--- a/tests/embeddings/test_jina.py
+++ b/tests/embeddings/test_jina.py
@@ -55,9 +55,7 @@ async def test_embed_batch_chunks_at_32(provider):
 @respx.mock
 async def test_embed_batch_supports_openai_style_response(provider):
     respx.post("http://tei-test:80/embed").mock(
-        return_value=httpx.Response(
-            200, json={"data": [{"embedding": [0.5] * 768}]}
-        )
+        return_value=httpx.Response(200, json={"data": [{"embedding": [0.5] * 768}]})
     )
     vectors = await provider.embed_batch(["hello"])
     assert vectors == [[0.5] * 768]

--- a/tests/embeddings/test_ollama.py
+++ b/tests/embeddings/test_ollama.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from server.config import settings
+from server.embeddings.ollama import OllamaEmbeddingProvider
+
+
+@pytest.fixture
+def ollama_settings(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "http://ollama-test:11434")
+    monkeypatch.setattr(settings, "ollama_model", "nomic-embed-text")
+    monkeypatch.setattr(settings, "ollama_dimensions", None)
+
+
+@pytest.fixture
+async def provider(ollama_settings):
+    p = OllamaEmbeddingProvider()
+    yield p
+    await p.close()
+
+
+def _vectors_response(inputs: list[str], dim: int = 768) -> dict:
+    return {"embeddings": [[0.0] * dim for _ in inputs]}
+
+
+def test_unknown_model_without_dimensions_raises(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "http://ollama-test:11434")
+    monkeypatch.setattr(settings, "ollama_model", "totally-custom-embed")
+    monkeypatch.setattr(settings, "ollama_dimensions", None)
+    with pytest.raises(RuntimeError, match="OLLAMA_DIMENSIONS"):
+        OllamaEmbeddingProvider()
+
+
+def test_dimensions_native(ollama_settings):
+    p = OllamaEmbeddingProvider()
+    assert p.dimensions == 768
+
+
+def test_dimensions_override(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "http://ollama-test:11434")
+    monkeypatch.setattr(settings, "ollama_model", "custom-embed")
+    monkeypatch.setattr(settings, "ollama_dimensions", 512)
+    p = OllamaEmbeddingProvider()
+    assert p.dimensions == 512
+
+
+@respx.mock
+async def test_embed_batch_request_shape(provider):
+    route = respx.post("http://ollama-test:11434/api/embed").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a", "b"]))
+    )
+    await provider.embed_batch(["a", "b"])
+    body = json.loads(route.calls.last.request.read())
+    assert body == {"model": "nomic-embed-text", "input": ["a", "b"]}
+
+
+@respx.mock
+async def test_embed_batch_chunks_at_32(provider):
+    route = respx.post("http://ollama-test:11434/api/embed").mock(
+        side_effect=lambda req: httpx.Response(
+            200,
+            json=_vectors_response(json.loads(req.read())["input"]),
+        )
+    )
+    inputs = [f"x-{i}" for i in range(70)]
+    vectors = await provider.embed_batch(inputs)
+    # 70 / 32 = 3 calls (32, 32, 6)
+    assert route.call_count == 3
+    assert len(vectors) == 70
+
+
+@respx.mock
+async def test_embed_query_returns_single_vector(provider):
+    respx.post("http://ollama-test:11434/api/embed").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["q"]))
+    )
+    vec = await provider.embed_query("q")
+    assert len(vec) == 768
+
+
+async def test_embed_batch_empty(provider):
+    assert await provider.embed_batch([]) == []

--- a/tests/embeddings/test_openai.py
+++ b/tests/embeddings/test_openai.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from server.config import settings
+from server.embeddings.openai import OpenAIEmbeddingProvider
+
+
+@pytest.fixture
+def openai_settings(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+    monkeypatch.setattr(settings, "openai_embedding_model", "text-embedding-3-large")
+    monkeypatch.setattr(settings, "openai_dimensions", None)
+
+
+@pytest.fixture
+async def provider(openai_settings):
+    p = OpenAIEmbeddingProvider()
+    yield p
+    await p.close()
+
+
+def _vectors_response(inputs: list[str], dim: int = 3072) -> dict:
+    return {"data": [{"embedding": [0.0] * dim} for _ in inputs]}
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", "")
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        OpenAIEmbeddingProvider()
+
+
+def test_unknown_model_without_dimensions_raises(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", "k")
+    monkeypatch.setattr(settings, "openai_embedding_model", "text-future-99")
+    monkeypatch.setattr(settings, "openai_dimensions", None)
+    with pytest.raises(RuntimeError, match="OPENAI_DIMENSIONS"):
+        OpenAIEmbeddingProvider()
+
+
+def test_dimensions_native(openai_settings):
+    p = OpenAIEmbeddingProvider()
+    assert p.dimensions == 3072  # text-embedding-3-large native
+
+
+def test_dimensions_override(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", "k")
+    monkeypatch.setattr(settings, "openai_embedding_model", "text-embedding-3-large")
+    monkeypatch.setattr(settings, "openai_dimensions", 1024)
+    p = OpenAIEmbeddingProvider()
+    assert p.dimensions == 1024
+
+
+@respx.mock
+async def test_embed_batch_request_shape(provider):
+    route = respx.post("https://api.openai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a", "b"]))
+    )
+    await provider.embed_batch(["a", "b"])
+    body = json.loads(route.calls.last.request.read())
+    assert body == {"model": "text-embedding-3-large", "input": ["a", "b"]}
+
+
+@respx.mock
+async def test_embed_batch_includes_dimensions_when_overridden(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+    monkeypatch.setattr(settings, "openai_embedding_model", "text-embedding-3-large")
+    monkeypatch.setattr(settings, "openai_dimensions", 512)
+
+    route = respx.post("https://api.openai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a"], dim=512))
+    )
+    p = OpenAIEmbeddingProvider()
+    try:
+        await p.embed_batch(["a"])
+    finally:
+        await p.close()
+    body = json.loads(route.calls.last.request.read())
+    assert body["dimensions"] == 512
+
+
+@respx.mock
+async def test_embed_batch_chunks_at_128(provider):
+    route = respx.post("https://api.openai.com/v1/embeddings").mock(
+        side_effect=lambda req: httpx.Response(
+            200,
+            json=_vectors_response(json.loads(req.read())["input"]),
+        )
+    )
+    inputs = [f"x-{i}" for i in range(257)]
+    vectors = await provider.embed_batch(inputs)
+    # 257 / 128 = 3 calls (128, 128, 1)
+    assert route.call_count == 3
+    assert len(vectors) == 257
+
+
+@respx.mock
+async def test_authorization_header_set(provider):
+    route = respx.post("https://api.openai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a"]))
+    )
+    await provider.embed_batch(["a"])
+    assert route.calls.last.request.headers.get("authorization") == "Bearer sk-test"
+
+
+@respx.mock
+async def test_embed_query_returns_single_vector(provider):
+    respx.post("https://api.openai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["q"]))
+    )
+    vec = await provider.embed_query("q")
+    assert len(vec) == 3072
+
+
+async def test_embed_batch_empty(provider):
+    assert await provider.embed_batch([]) == []

--- a/tests/embeddings/test_voyage.py
+++ b/tests/embeddings/test_voyage.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from server.config import settings
+from server.embeddings.voyage import VoyageEmbeddingProvider
+
+
+@pytest.fixture
+def voyage_settings(monkeypatch):
+    monkeypatch.setattr(settings, "voyage_api_key", "test-key")
+    monkeypatch.setattr(settings, "voyage_model", "voyage-code-3")
+    monkeypatch.setattr(settings, "voyage_dimensions", None)
+
+
+@pytest.fixture
+async def provider(voyage_settings):
+    p = VoyageEmbeddingProvider()
+    yield p
+    await p.close()
+
+
+def _vectors_response(inputs: list[str], dim: int = 1024) -> dict:
+    return {"data": [{"embedding": [0.1] * dim} for _ in inputs]}
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.setattr(settings, "voyage_api_key", "")
+    with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+        VoyageEmbeddingProvider()
+
+
+def test_unknown_model_without_dimensions_raises(monkeypatch):
+    monkeypatch.setattr(settings, "voyage_api_key", "k")
+    monkeypatch.setattr(settings, "voyage_model", "voyage-future-99")
+    monkeypatch.setattr(settings, "voyage_dimensions", None)
+    with pytest.raises(RuntimeError, match="VOYAGE_DIMENSIONS"):
+        VoyageEmbeddingProvider()
+
+
+def test_dimensions_native(voyage_settings):
+    p = VoyageEmbeddingProvider()
+    assert p.dimensions == 1024  # voyage-code-3 native
+
+
+def test_dimensions_override(monkeypatch):
+    monkeypatch.setattr(settings, "voyage_api_key", "k")
+    monkeypatch.setattr(settings, "voyage_model", "voyage-code-3")
+    monkeypatch.setattr(settings, "voyage_dimensions", 256)
+    p = VoyageEmbeddingProvider()
+    assert p.dimensions == 256
+
+
+@respx.mock
+async def test_embed_batch_uses_document_input_type(provider):
+    route = respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a", "b"]))
+    )
+    await provider.embed_batch(["a", "b"])
+    body = json.loads(route.calls.last.request.read())
+    assert body["model"] == "voyage-code-3"
+    assert body["input"] == ["a", "b"]
+    assert body["input_type"] == "document"
+    assert "output_dimension" not in body
+
+
+@respx.mock
+async def test_embed_query_uses_query_input_type(provider):
+    route = respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["q"]))
+    )
+    await provider.embed_query("q")
+    body = json.loads(route.calls.last.request.read())
+    assert body["input_type"] == "query"
+    assert body["input"] == ["q"]
+
+
+@respx.mock
+async def test_embed_batch_chunks_at_128(provider):
+    route = respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        side_effect=lambda req: httpx.Response(
+            200,
+            json=_vectors_response(json.loads(req.read())["input"]),
+        )
+    )
+    inputs = [f"text-{i}" for i in range(300)]
+    vectors = await provider.embed_batch(inputs)
+    # 300 / 128 = 3 calls (128, 128, 44)
+    assert route.call_count == 3
+    assert len(vectors) == 300
+
+
+@respx.mock
+async def test_authorization_header_set(provider):
+    route = respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a"]))
+    )
+    await provider.embed_batch(["a"])
+    auth = route.calls.last.request.headers.get("authorization")
+    assert auth == "Bearer test-key"
+
+
+@respx.mock
+async def test_embed_batch_passes_output_dimension_when_overridden(monkeypatch):
+    monkeypatch.setattr(settings, "voyage_api_key", "test-key")
+    monkeypatch.setattr(settings, "voyage_model", "voyage-code-3")
+    monkeypatch.setattr(settings, "voyage_dimensions", 512)
+
+    route = respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        return_value=httpx.Response(200, json=_vectors_response(["a"], dim=512))
+    )
+    p = VoyageEmbeddingProvider()
+    try:
+        await p.embed_batch(["a"])
+    finally:
+        await p.close()
+    body = json.loads(route.calls.last.request.read())
+    assert body["output_dimension"] == 512
+
+
+async def test_embed_batch_empty(provider):
+    assert await provider.embed_batch([]) == []

--- a/tests/embeddings/test_voyage.py
+++ b/tests/embeddings/test_voyage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 import httpx
@@ -124,3 +125,39 @@ async def test_embed_batch_passes_output_dimension_when_overridden(monkeypatch):
 
 async def test_embed_batch_empty(provider):
     assert await provider.embed_batch([]) == []
+
+
+@respx.mock
+async def test_rate_limit_backoff_delays(provider, monkeypatch):
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        side_effect=[
+            httpx.Response(429),
+            httpx.Response(429),
+            httpx.Response(429),
+            httpx.Response(200, json=_vectors_response(["a"])),
+        ]
+    )
+    await provider.embed_batch(["a"])
+    assert sleep_calls == [10, 20, 30]
+
+
+@respx.mock
+async def test_rate_limit_all_retries_exhausted_raises(provider, monkeypatch):
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    respx.post("https://api.voyageai.com/v1/embeddings").mock(
+        return_value=httpx.Response(429)
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await provider.embed_batch(["a"])
+    assert sleep_calls == [10, 20, 30, 40]


### PR DESCRIPTION
Introduce an EmbeddingProvider factory and provider implementations so the embedding backend is selectable via EMBEDDINGS_PROVIDER. Vector dimensions are now derived from the active provider and threaded through the Qdrant stores, which fail fast on a dimension mismatch with an existing collection.

https://github.com/GoodbyePlanet/semcode/issues/22