### PR TITLE
fix: minor style/consistency cleanups

### DIFF
--- a/server/indexer/github_source.py
+++ b/server/indexer/github_source.py
@@ -324,11 +324,12 @@ async def fetch_commits_with_diffs(
     commits: list[GitHubCommit],
     max_files: int = 50,
     max_patch_chars: int = 2000,
+    client: httpx.AsyncClient | None = None,
 ) -> list[GitHubCommit]:
     """Fetch diff details for a batch of commits in parallel, bounded by a semaphore."""
     sem = asyncio.Semaphore(_DIFF_CONCURRENCY)
 
-    async with httpx.AsyncClient() as shared_client:
+    async with _client_ctx(client) as shared_client:
 
         async def _fetch_one(commit: GitHubCommit) -> GitHubCommit:
             async with sem:

--- a/server/parser/python.py
+++ b/server/parser/python.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 
 import tree_sitter_python
 from tree_sitter import Language, Node, Parser
@@ -49,8 +50,6 @@ def _get_fastapi_route(decorators: list[str]) -> tuple[str | None, str | None]:
             if f".{method}(" in dec or dec.startswith(f"{method}("):
                 route = None
                 # Extract path string from decorator like router.get("/api/chat")
-                import re
-
                 m = re.search(r'["\']([^"\']+)["\']', dec)
                 if m:
                     route = m.group(1)

--- a/server/tools/history.py
+++ b/server/tools/history.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from server.embeddings.factory import get_embedding_provider
+from server.embeddings import get_embedding_provider
 from server.indexer.git_history import GitHistoryPipeline
 from server.state import get_commit_store
 


### PR DESCRIPTION
## Summary
- Hoist `import re` out of the per-decorator loop in `_get_fastapi_route` (`server/parser/python.py`)
- `fetch_commits_with_diffs` now accepts an optional `client` and uses the `_client_ctx` pattern its siblings follow, instead of always opening its own `httpx.AsyncClient` (`server/indexer/github_source.py`)
- Import `get_embedding_provider` from `server.embeddings` in `history.py` to match `search.py`'s import path, instead of `server.embeddings.factory`

The fourth item from the issue (a shared `TreeSitterParser` base class to de-duplicate boilerplate across the 21 language parsers) was intentionally left out — the issue itself flags it as lower priority since per-language node logic genuinely differs, and it's a much larger, riskier refactor better suited to its own PR.

Fixes #80

## Test plan
- [x] `uv run pytest` — 217 passed